### PR TITLE
feat: add base rpc extractor

### DIFF
--- a/.changeset/add-base-evm-extractor.md
+++ b/.changeset/add-base-evm-extractor.md
@@ -1,0 +1,5 @@
+---
+'@rosen-bridge/evm-observation-extractor': minor
+---
+
+Add a Base RPC observation extractor alongside the shared EVM extractor exports.

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,6 @@
       "version": "7.28.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1595,7 +1594,8 @@
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1972,6 +1972,7 @@
       "version": "1.1.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"
@@ -1981,6 +1982,7 @@
       "version": "1.1.2",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
@@ -1993,6 +1995,7 @@
       "version": "3.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -2942,6 +2945,7 @@
       "version": "1.1.2",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -3062,7 +3066,6 @@
     "node_modules/@types/node": {
       "version": "22.18.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3129,7 +3132,6 @@
       "version": "8.46.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -3498,13 +3500,13 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3530,6 +3532,7 @@
       "version": "6.0.2",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -3541,6 +3544,7 @@
       "version": "4.2.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "^4.1.0",
         "depd": "^1.1.2",
@@ -3647,7 +3651,8 @@
     "node_modules/aproba": {
       "version": "2.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3839,6 +3844,7 @@
     "node_modules/bindings": {
       "version": "1.5.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -3872,6 +3878,7 @@
     "node_modules/bl": {
       "version": "4.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -3895,6 +3902,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -3969,7 +3977,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4039,6 +4046,7 @@
       "version": "15.3.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@npmcli/fs": "^1.0.0",
         "@npmcli/move-file": "^1.0.1",
@@ -4067,6 +4075,7 @@
       "version": "3.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4261,6 +4270,7 @@
     "node_modules/chownr": {
       "version": "2.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4402,6 +4412,7 @@
       "version": "1.1.3",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -4437,7 +4448,8 @@
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -4596,6 +4608,7 @@
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -4665,12 +4678,14 @@
     "node_modules/delegates": {
       "version": "1.0.0",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/depd": {
       "version": "1.1.2",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4686,6 +4701,7 @@
     "node_modules/detect-libc": {
       "version": "2.0.2",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4759,6 +4775,7 @@
       "version": "2.2.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4770,7 +4787,8 @@
     "node_modules/err-code": {
       "version": "2.0.3",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -5000,7 +5018,6 @@
       "version": "9.37.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5336,6 +5353,7 @@
     "node_modules/expand-template": {
       "version": "2.0.3",
       "license": "(MIT OR WTFPL)",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5461,7 +5479,8 @@
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -5597,7 +5616,8 @@
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fs-extra": {
       "version": "7.0.1",
@@ -5615,6 +5635,7 @@
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -5625,7 +5646,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -5759,12 +5781,14 @@
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glob": {
       "version": "7.2.3",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5955,7 +5979,8 @@
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -5987,6 +6012,7 @@
       "version": "4.0.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -6011,6 +6037,7 @@
       "version": "5.0.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -6028,6 +6055,7 @@
       "version": "1.2.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -6106,12 +6134,14 @@
     "node_modules/infer-owner": {
       "version": "1.0.4",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6123,7 +6153,8 @@
     },
     "node_modules/ini": {
       "version": "1.3.8",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -6141,7 +6172,8 @@
     "node_modules/ip": {
       "version": "2.0.0",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
@@ -6257,7 +6289,8 @@
     "node_modules/is-lambda": {
       "version": "1.0.1",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
@@ -6503,7 +6536,6 @@
       "version": "2.6.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -7014,6 +7046,7 @@
       "version": "6.0.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -7063,6 +7096,7 @@
       "version": "9.1.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agentkeepalive": "^4.1.3",
         "cacache": "^15.2.0",
@@ -7249,6 +7283,7 @@
     "node_modules/minipass": {
       "version": "3.3.4",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -7260,6 +7295,7 @@
       "version": "1.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -7271,6 +7307,7 @@
       "version": "1.4.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.1.0",
         "minipass-sized": "^1.0.3",
@@ -7287,6 +7324,7 @@
       "version": "1.0.5",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -7298,6 +7336,7 @@
       "version": "1.2.4",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -7309,6 +7348,7 @@
       "version": "1.0.3",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -7319,6 +7359,7 @@
     "node_modules/minizlib": {
       "version": "2.1.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -7338,6 +7379,7 @@
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -7347,7 +7389,8 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -7375,7 +7418,8 @@
     },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -7386,6 +7430,7 @@
       "version": "0.6.3",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7393,6 +7438,7 @@
     "node_modules/node-abi": {
       "version": "3.56.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -7403,6 +7449,7 @@
     "node_modules/node-addon-api": {
       "version": "7.1.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^16 || ^18 || >= 20"
       }
@@ -7429,6 +7476,7 @@
       "version": "8.4.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
@@ -7452,6 +7500,7 @@
       "version": "3.0.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -7464,6 +7513,7 @@
       "version": "4.0.4",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.3",
@@ -7482,6 +7532,7 @@
       "version": "6.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "are-we-there-yet": "^3.0.0",
         "console-control-strings": "^1.1.0",
@@ -7496,6 +7547,7 @@
       "version": "3.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7522,6 +7574,7 @@
       "version": "5.0.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -7839,6 +7892,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8032,6 +8086,7 @@
     "node_modules/prebuild-install": {
       "version": "7.1.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -8079,7 +8134,6 @@
       "version": "3.6.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8093,12 +8147,14 @@
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -8166,6 +8222,7 @@
     "node_modules/rc": {
       "version": "1.2.8",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -8179,6 +8236,7 @@
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8322,6 +8380,7 @@
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -8454,6 +8513,7 @@
       "version": "0.12.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -8782,7 +8842,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -8801,6 +8862,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -8856,6 +8918,7 @@
       "version": "4.2.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -9004,6 +9067,7 @@
       "version": "2.7.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -9017,6 +9081,7 @@
       "version": "6.2.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^6.0.2",
         "debug": "^4.3.3",
@@ -9171,6 +9236,7 @@
       "version": "8.0.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.1.1"
       },
@@ -9201,6 +9267,7 @@
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -9221,7 +9288,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/string-argv": {
       "version": "0.3.1",
@@ -9386,6 +9454,7 @@
     "node_modules/tar": {
       "version": "6.1.11",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -9401,6 +9470,7 @@
     "node_modules/tar-fs": {
       "version": "2.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -9410,11 +9480,13 @@
     },
     "node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -9584,7 +9656,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9684,7 +9755,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -9768,6 +9838,7 @@
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -10073,7 +10144,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10104,6 +10174,7 @@
       "version": "1.1.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "unique-slug": "^2.0.0"
       }
@@ -10112,6 +10183,7 @@
       "version": "2.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       }
@@ -10163,7 +10235,8 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/uuid": {
       "version": "9.0.0",
@@ -10196,7 +10269,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10763,7 +10835,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10777,7 +10848,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -10966,6 +11036,7 @@
       "version": "1.1.5",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
@@ -11008,7 +11079,6 @@
     "node_modules/ws": {
       "version": "7.5.10",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -11034,7 +11104,8 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yaml": {
       "version": "2.7.0",
@@ -11379,10 +11450,10 @@
     },
     "packages/reward-extractor": {
       "name": "@rosen-bridge/reward-extractor",
-      "version": "0.0.1",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@rosen-bridge/abstract-extractor": "^3.1.1",
+        "@rosen-bridge/abstract-extractor": "^3.1.0",
         "@rosen-bridge/abstract-logger": "^4.0.0",
         "@rosen-bridge/extended-typeorm": "^1.0.1",
         "@rosen-bridge/json-bigint": "^1.1.0",

--- a/packages/observation-extractors/evm-observation-extractor/lib/baseRpcObservationExtractor.ts
+++ b/packages/observation-extractors/evm-observation-extractor/lib/baseRpcObservationExtractor.ts
@@ -1,0 +1,34 @@
+import { AbstractLogger } from '@rosen-bridge/abstract-logger';
+import { DataSource } from '@rosen-bridge/extended-typeorm';
+import { EvmEthersRosenExtractor } from '@rosen-bridge/rosen-extractor';
+import { TokenMap } from '@rosen-bridge/tokens';
+
+import { EvmRpcObservationExtractor } from './evmRpcObservationExtractor';
+
+export class BaseRpcObservationExtractor extends EvmRpcObservationExtractor {
+  readonly FROM_CHAIN = 'base';
+
+  constructor(
+    lockAddress: string,
+    dataSource: DataSource,
+    tokens: TokenMap,
+    logger?: AbstractLogger,
+    storeRawData = true,
+  ) {
+    super(
+      dataSource,
+      tokens,
+      new EvmEthersRosenExtractor(
+        lockAddress,
+        tokens,
+        'base',
+        'eth',
+        logger?.child('EvmEthersRosenExtractor'),
+        storeRawData,
+      ),
+      logger,
+    );
+  }
+
+  getId = () => 'base-rpc-extractor';
+}

--- a/packages/observation-extractors/evm-observation-extractor/lib/index.ts
+++ b/packages/observation-extractors/evm-observation-extractor/lib/index.ts
@@ -1,3 +1,4 @@
+export * from './baseRpcObservationExtractor';
 export * from './binanceRpcObservationExtractor';
 export * from './ethereumRpcObservationExtractor';
 export * from './evmRpcObservationExtractor';


### PR DESCRIPTION
## Summary
Add the Base RPC observation extractor.

## Changes
- add Base EVM observation extractor
- export the new extractor from the package index

## Notes
- follows the existing Ethereum and Binance extractor pattern